### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/lib/objectUtils.js
+++ b/lib/objectUtils.js
@@ -122,6 +122,11 @@ function unflatten(object, separator) {
 module.exports.unflatten = unflatten;
 
 function deepSet(object, property, value) {
+
+    if (property.includes('__proto__') || property.includes('constructor') || property.includes('prototype')) {
+        return false;
+    }
+
     if(isUndefined(object) || object === null) {
         return false;
     }
@@ -150,6 +155,12 @@ function deepSet(object, property, value) {
 module.exports.deepSet = deepSet;
 
 function deepMerge(destination, source) {
+    var key = Object.keys(source);
+    
+    if (key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')) {
+        return false;
+    }
+
     if(isUndefined(destination)) {
         destination = {};
     }


### PR DESCRIPTION
https://huntr.dev/users/Asjidkalam has fixed the Prototype Pollution vulnerability 🔨. Asjidkalam has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/utils/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/gammautils/1/README.md

### User Comments:

### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-gammautils

### ⚙️ Description *

gammautils is a Lots of utilities for Node.js, this package is vulnerable to Prototype Pollution via the. deepSet and deepMerge functions.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `key` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `123`.
```javascript
const gammautils = require('gammautils');
var payload = JSON.parse('{""__proto__"":{""polluted"":true}}');
gammautils.object.deepSet({}, '__proto__.polluted2', true);
gammautils.object.deepMerge({}, payload);
console.log(polluted);
console.log(polluted2);
```

![image](https://user-images.githubusercontent.com/16708391/92943629-a467c500-f470-11ea-8882-960fc5dd8276.png)



### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns an error since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/92943776-d37e3680-f470-11ea-95c2-99e9035b1faf.png)


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `key`, `destination` and no breaking changes are introduced. :)
